### PR TITLE
feat(fs): close stream before ending

### DIFF
--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -21,7 +21,9 @@ module.exports = {
         stream.once('error', err => dataSocket.emit('error', err));
         stream.once('finish', () => resolve(this.reply(226, fileName)));
 
-        dataSocket.once('end', () => stream.emit('close'));
+        // Emit `close` if stream has a close listener, otherwise emit `finish` with the end() method
+        // It is assumed that the `close` handler will call the end() method
+        dataSocket.once('end', () => stream.listenerCount('close') ? stream.emit('close') : stream.end());
         dataSocket.once('error', err => reject(err));
         dataSocket.on('data', data => stream.write(data, this.encoding));
 

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -26,7 +26,8 @@ module.exports = {
         dataSocket.on('data', data => stream.write(data, this.encoding));
 
         this.reply(150).then(() => dataSocket.resume());
-      });
+      })
+      .finally(() => when.try(stream.destroy.bind(stream)));
     })
     .catch(when.TimeoutError, err => {
       log.error(err);

--- a/src/fs.js
+++ b/src/fs.js
@@ -68,7 +68,8 @@ class FileSystem {
   write(fileName, {append = false} = {}) {
     const {fsPath} = this._resolvePath(fileName);
     const stream = syncFs.createWriteStream(fsPath, {flags: !append ? 'w+' : 'a+'});
-    stream.on('error', () => fs.unlink(fsPath));
+    stream.once('error', () => fs.unlink(fsPath));
+    stream.once('close', () => stream.end());
     return stream;
   }
 


### PR DESCRIPTION
This allows processing of the received data before a response is sent to the client.