### PR TITLE
Make FileSystem properties visible

### DIFF
--- a/ftp-srv.d.ts
+++ b/ftp-srv.d.ts
@@ -3,9 +3,9 @@ import { Stats } from 'fs'
 
 export class FileSystem {
 
-	public connection: FtpConnection;
-	public root: string;
-	public cwd: string;
+	readonly connection: FtpConnection;
+	readonly root: string;
+	readonly cwd: string;
 
     constructor(connection: FtpConnection, {root, cwd}?: {
         root: any;

--- a/ftp-srv.d.ts
+++ b/ftp-srv.d.ts
@@ -2,7 +2,12 @@ import * as tls from 'tls'
 import { Stats } from 'fs'
 
 export class FileSystem {
-    constructor(connection: any, {root, cwd}?: {
+
+	public connection: FtpConnection;
+	public root: string;
+	public cwd: string;
+
+    constructor(connection: FtpConnection, {root, cwd}?: {
         root: any;
         cwd: any;
     });


### PR DESCRIPTION
Makes `connection`, `root`, and `cwd` in FileSystem class `readonly`.

I believe this is the proper scoping. If any other contributor could let me know if that is correct that would be great 😄.