### PR TITLE
fix: retr command, pause and resume  readablestream

### DIFF
--- a/src/commands/registration/retr.js
+++ b/src/commands/registration/retr.js
@@ -15,9 +15,20 @@ module.exports = {
       const eventsPromise = when.promise((resolve, reject) => {
         this.connector.socket.once('error', err => reject(err));
 
-        stream.on('data', data => this.connector.socket
-          && this.connector.socket.write(data, this.transferType));
-        stream.once('error', err => reject(err));
+        stream.on('data', data => {
+          stream.pause()
+          this.connector.socket
+            && this.connector.socket.write(data, this.transferType, function(){
+              stream.resume()
+            })
+        });
+        
+        stream.once('error', err => {
+          // DESTROY STREAM WHEN ERROR HAPPENED
+          if(stream.destroy)
+            stream.destroy()
+          return reject(err)
+        });
         stream.once('end', () => resolve());
       });
 


### PR DESCRIPTION
I will explain why this pull is needed. For example, a client with 500Kbps network speed start downloading a 1GB file. Without my code, all BYTES continue writing to socket and get buffered in memory almost all 1GB because the client cannot download in a good speed. WIth this code, the stream is paused, and resume after complete each chunk write in socket

Also when error ocurred is better destroy the readable stream