### PR TITLE
fix: retr commad, pause and resume readable stream

### DIFF
--- a/src/commands/registration/retr.js
+++ b/src/commands/registration/retr.js
@@ -15,9 +15,20 @@ module.exports = {
       const eventsPromise = when.promise((resolve, reject) => {
         this.connector.socket.once('error', err => reject(err));
 
-        stream.on('data', data => this.connector.socket
-          && this.connector.socket.write(data, this.transferType));
-        stream.once('error', err => reject(err));
+        stream.on('data', data => {
+          stream.pause()
+          this.connector.socket
+            && this.connector.socket.write(data, this.transferType, function(){
+              stream.resume()
+            })
+        });
+        
+        stream.once('error', err => {
+          // DESTROY STREAM WHEN ERROR HAPPENED
+          if(stream.destroy)
+            stream.destroy()
+          return reject(err)
+        });
         stream.once('end', () => resolve());
       });
 

--- a/src/commands/registration/retr.js
+++ b/src/commands/registration/retr.js
@@ -13,7 +13,13 @@ module.exports = {
       this.restByteCount = 0;
 
       const eventsPromise = when.promise((resolve, reject) => {
-        this.connector.socket.once('error', err => reject(err));
+        this.connector.socket.once('error', err => {
+          // https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_destroy_err_callback
+          if(stream.destroy) stream.destroy()
+          // this for get fallback in nodejs v6
+          else if(stream._destroy) stream._destroy()
+          reject(err)
+        });
 
         stream.on('data', data => {
           stream.pause()
@@ -24,9 +30,10 @@ module.exports = {
         });
         
         stream.once('error', err => {
-          // DESTROY STREAM WHEN ERROR HAPPENED
-          if(stream.destroy)
-            stream.destroy()
+          // https://nodejs.org/dist/latest-v8.x/docs/api/stream.html#stream_readable_destroy_err_callback
+          if(stream.destroy) stream.destroy()
+          // this for get fallback in nodejs v6
+          else if(stream._destroy) stream._destroy()
           return reject(err)
         });
         stream.once('end', () => resolve());

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -13,26 +13,33 @@ module.exports = {
     .tap(() => this.commandSocket.pause())
     .then(() => when.try(this.fs.write.bind(this.fs), fileName, {append, start: this.restByteCount}))
     .then(stream => {
-      this.restByteCount = 0;
+      const destroyConnection = (connection, reject) => err => connection && connection.destroy(err) && reject(err);
 
       const streamPromise = when.promise((resolve, reject) => {
-        stream.once('error', err => reject(err));
+        stream.once('error', destroyConnection(this.connector.socket, reject));
         stream.once('finish', () => resolve());
       });
 
       const socketPromise = when.promise((resolve, reject) => {
-        this.connector.socket.on('data', data => stream.write(data, this.transferType));
+        this.connector.socket.on('data', data => {
+          this.connector.socket && this.connector.socket.pause();
+          if (stream) {
+            stream.write(data, this.transferType, () => this.connector.socket && this.connector.socket.resume());
+          }
+        });
         this.connector.socket.once('end', () => {
           if (stream.listenerCount('close')) stream.emit('close');
           else stream.end();
           resolve();
         });
-        this.connector.socket.once('error', err => reject(err));
+        this.connector.socket.once('error', destroyConnection(stream, reject));
       });
+
+      this.restByteCount = 0;
 
       return this.reply(150).then(() => this.connector.socket.resume())
       .then(() => when.join(streamPromise, socketPromise))
-      .finally(() => stream.destroy ? stream.destroy() : null);
+      .finally(() => stream.destroy && stream.destroy());
     })
     .then(() => this.reply(226, fileName))
     .catch(when.TimeoutError, err => {


### PR DESCRIPTION
I will explain why this pull is needed. For example, a client with 500Kbps network speed start downloading a 1GB file. Without my code, all BYTES continue writing to socket and get buffered in memory almost all 1GB because the client cannot download in a good speed. WIth this code, the stream is paused, and resume after complete each chunk write in socket

Also when error ocurred is better destroy the readable stream, for free some possible socket open inside ReadableStream or similar. 