### PR TITLE
Emit custom events

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The `FtpSrv` class extends the [node net.Server](https://nodejs.org/api/net.html
 
 ### `login`
 ```js
-on('login', {connection, username, password}, resolve, reject) => { ... }
+on('login', ({connection, username, password}, resolve, reject) => { ... });
 ```
 
 Occurs when a client is attempting to login. Here you can resolve the login request by username and password.
@@ -152,7 +152,7 @@ Occurs when a client is attempting to login. Here you can resolve the login requ
 
 ### `client-error`
 ```js
-on('client-error', {connection, context, error}) => { ... }
+on('client-error', ({connection, context, error}) => { ... });
 ```
 
 Occurs when an error arises in the client connection.
@@ -160,6 +160,26 @@ Occurs when an error arises in the client connection.
 `connection` [client class object](src/connection.js)  
 `context` string of where the error occured  
 `error` error object
+
+### `RETR`
+```js
+on('RETR', (error, filePath) => { ... });
+```
+
+Occurs when a file is downloaded.
+
+`error` if successful, will be `null`
+`filePath` location to which file was downloaded
+
+### `STOR`
+```js
+on('STOR', (error, fileName) => { ... });
+```
+
+Occurs when a file is uploaded.
+
+`error` if successful, will be `null`
+`fileName` name of the file that was downloaded
 
 ## Supported Commands
 

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -42,6 +42,7 @@ module.exports = {
 
       return this.reply(150).then(() => this.connector.socket.resume())
       .then(() => Promise.join(streamPromise, socketPromise))
+      .tap(() => this.emit('STOR', null, fileName))
       .finally(() => stream.destroy && stream.destroy());
     })
     .then(() => this.reply(226, fileName))
@@ -51,6 +52,7 @@ module.exports = {
     })
     .catch(err => {
       log.error(err);
+      this.emit('STOR', err);
       return this.reply(550, err.message);
     })
     .finally(() => {

--- a/src/connection.js
+++ b/src/connection.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const uuid = require('uuid');
 const Promise = require('bluebird');
+const EventEmitter = require('events');
 
 const BaseConnector = require('./connector/base');
 const FileSystem = require('./fs');
@@ -8,8 +9,9 @@ const Commands = require('./commands');
 const errors = require('./errors');
 const DEFAULT_MESSAGE = require('./messages');
 
-class FtpConnection {
+class FtpConnection extends EventEmitter {
   constructor(server, options) {
+    super();
     this.server = server;
     this.id = uuid.v4();
     this.log = options.log.child({id: this.id, ip: this.ip});

--- a/src/connection.js
+++ b/src/connection.js
@@ -34,6 +34,7 @@ class FtpConnection extends EventEmitter {
     this.commandSocket.on('close', () => {
       if (this.connector) this.connector.end();
       if (this.commandSocket && !this.commandSocket.destroyed) this.commandSocket.destroy();
+      this.removeAllListeners();
     });
   }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -46,7 +46,7 @@ class FtpConnection extends EventEmitter {
 
   get ip() {
     try {
-      return this.dataSocket ? this.dataSocket.remoteAddress : this.commandSocket.remoteAddress;
+      return this.commandSocket ? this.commandSocket.remoteAddress : undefined;
     } catch (ex) {
       return null;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,8 @@ class FtpServer extends EventEmitter {
         if (err) this.log.error(err, 'Error closing server');
         resolve('Closed');
       });
-    }));
+    }))
+    .then(() => this.removeAllListeners());
   }
 
 }

--- a/test/commands/registration/retr.spec.js
+++ b/test/commands/registration/retr.spec.js
@@ -2,11 +2,13 @@ const Promise = require('bluebird');
 const bunyan = require('bunyan');
 const {expect} = require('chai');
 const sinon = require('sinon');
+const EventEmitter = require('events');
 
 const CMD = 'RETR';
 describe(CMD, function () {
   let sandbox;
   let log = bunyan.createLogger({name: CMD});
+  let emitter;
   const mockClient = {
     commandSocket: {
       pause: () => {},
@@ -28,6 +30,11 @@ describe(CMD, function () {
     mockClient.fs = {
       read: () => {}
     };
+
+    emitter = new EventEmitter();
+    mockClient.emit = emitter.emit.bind(emitter);
+    mockClient.on = emitter.on.bind(emitter);
+    mockClient.once = emitter.once.bind(emitter);
 
     sandbox.spy(mockClient, 'reply');
   });
@@ -56,6 +63,7 @@ describe(CMD, function () {
       return Promise.reject(new Promise.TimeoutError());
     });
 
+
     return cmdFn({log, command: {arg: 'test.txt'}})
     .then(() => {
       expect(mockClient.reply.args[0][0]).to.equal(425);
@@ -70,6 +78,22 @@ describe(CMD, function () {
     return cmdFn({log, command: {arg: 'test.txt'}})
     .then(() => {
       expect(mockClient.reply.args[0][0]).to.equal(551);
+    });
+  });
+
+  it('// unsuccessful | emits error event', () => {
+    sandbox.stub(mockClient.connector, 'waitForConnection').callsFake(function () {
+      return Promise.reject(new Error('test'));
+    });
+
+    let errorEmitted = false;
+    emitter.once('RETR', err => {
+      errorEmitted = !!err;
+    });
+
+    return cmdFn({log, command: {arg: 'test.txt'}})
+    .then(() => {
+      expect(errorEmitted).to.equal(true);
     });
   });
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -189,6 +189,11 @@ describe('Integration', function () {
     it('STOR tést.txt', done => {
       const buffer = Buffer.from('test text file');
       const fsPath = `${clientDirectory}/${name}/tést.txt`;
+
+      connection.once('STOR', err => {
+        expect(err).to.not.exist;
+      });
+
       client.put(buffer, 'tést.txt', err => {
         expect(err).to.not.exist;
         setTimeout(() => {
@@ -219,6 +224,10 @@ describe('Integration', function () {
     });
 
     it('RETR tést.txt', done => {
+      connection.once('RETR', err => {
+        expect(err).to.not.exist;
+      });
+
       client.get('tést.txt', (err, stream) => {
         expect(err).to.not.exist;
         let text = '';


### PR DESCRIPTION
Server and Connection now extend `EventEmitter`, allowing for custom events on both.

Adds `STOR` and `RETR` events on completion and failure of file upload and download respectively.

#### TODO:
- [ ] More events?
- [ ] Update docs