### PR TITLE
fix(typings): updated typescript typings

### DIFF
--- a/ftp-srv.d.ts
+++ b/ftp-srv.d.ts
@@ -1,5 +1,6 @@
 import * as tls from 'tls'
 import { Stats } from 'fs'
+import { EventEmitter } from 'events';
 
 export class FileSystem {
 
@@ -107,7 +108,7 @@ export class FtpServer {
             whitelist?: Array<string>
         }) => void,
 		reject: (err?: Error) => void
-	) => void)
+	) => void): EventEmitter;
 
 	on(event: "client-error", listener: (
 		data: {
@@ -115,7 +116,7 @@ export class FtpServer {
 			context: string,
 			error: Error,
 		}
-	) => void)
+	) => void): EventEmitter;
 }
 
 export {FtpServer as FtpSrv};


### PR DESCRIPTION
Updated TypeScript typings to allow compiling with `noImplicitAny` option enabled in tsconfig.json. Without this change when compiling i see:

```
node_modules/ftp-srv/ftp-srv.d.ts(96,2): error TS7010: 'on', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/ftp-srv/ftp-srv.d.ts(112,2): error TS7010: 'on', which lacks return-type annotation, implicitly has an 'any' return type.
```