### PR TITLE
feat: respond with full paths in STOR/RETR

### DIFF
--- a/src/commands/registration/retr.js
+++ b/src/commands/registration/retr.js
@@ -11,7 +11,14 @@ module.exports = {
     return this.connector.waitForConnection()
     .tap(() => this.commandSocket.pause())
     .then(() => Promise.resolve(this.fs.read(filePath, {start: this.restByteCount})))
-    .then(stream => {
+    .then(fsResponse => {
+      let {stream, clientPath} = fsResponse;
+      if (!stream && !clientPath) {
+        stream = fsResponse;
+        clientPath = filePath;
+      }
+      const serverPath = stream.path || filePath;
+
       const destroyConnection = (connection, reject) => err => {
         if (connection) connection.destroy(err);
         reject(err);
@@ -34,10 +41,10 @@ module.exports = {
 
       return this.reply(150).then(() => stream.resume() && this.connector.socket.resume())
       .then(() => eventsPromise)
-      .tap(() => this.emit('RETR', null, filePath))
+      .tap(() => this.emit('RETR', null, serverPath))
+      .then(() => this.reply(226, clientPath))
       .finally(() => stream.destroy && stream.destroy());
     })
-    .then(() => this.reply(226))
     .catch(Promise.TimeoutError, err => {
       log.error(err);
       return this.reply(425, 'No connection established');

--- a/test/fs.spec.js
+++ b/test/fs.spec.js
@@ -17,7 +17,7 @@ describe('FileSystem', function () {
     it('gets correct relative path', function () {
       const result = fs._resolvePath();
       expect(result).to.be.an('object');
-      expect(result.serverPath).to.equal(
+      expect(result.clientPath).to.equal(
         nodePath.normalize('/file/1/2/3'));
       expect(result.fsPath).to.equal(
         nodePath.resolve('/tmp/ftp-srv/file/1/2/3'));
@@ -26,7 +26,7 @@ describe('FileSystem', function () {
     it('gets correct relative path', function () {
       const result = fs._resolvePath('..');
       expect(result).to.be.an('object');
-      expect(result.serverPath).to.equal(
+      expect(result.clientPath).to.equal(
         nodePath.normalize('/file/1/2'));
       expect(result.fsPath).to.equal(
         nodePath.resolve('/tmp/ftp-srv/file/1/2'));
@@ -35,7 +35,7 @@ describe('FileSystem', function () {
     it('gets correct absolute path', function () {
       const result = fs._resolvePath('/other');
       expect(result).to.be.an('object');
-      expect(result.serverPath).to.equal(
+      expect(result.clientPath).to.equal(
         nodePath.normalize('/other'));
       expect(result.fsPath).to.equal(
         nodePath.resolve('/tmp/ftp-srv/other'));
@@ -44,7 +44,7 @@ describe('FileSystem', function () {
     it('cannot escape root', function () {
       const result = fs._resolvePath('../../../../../../../../../../..');
       expect(result).to.be.an('object');
-      expect(result.serverPath).to.equal(
+      expect(result.clientPath).to.equal(
         nodePath.normalize('/'));
       expect(result.fsPath).to.equal(
         nodePath.resolve('/tmp/ftp-srv'));
@@ -53,7 +53,7 @@ describe('FileSystem', function () {
     it('resolves to file', function () {
       const result = fs._resolvePath('/cool/file.txt');
       expect(result).to.be.an('object');
-      expect(result.serverPath).to.equal(
+      expect(result.clientPath).to.equal(
         nodePath.normalize('/cool/file.txt'));
       expect(result.fsPath).to.equal(
         nodePath.resolve('/tmp/ftp-srv/cool/file.txt'));


### PR DESCRIPTION
Emit and reply with the full paths to the files.

BREAKING CHANGE: fs expects an object `{stream, clientPath}` in response to `.read()` and `.write()`.

This is implemented in a backwards compatible way, and works with the old `fs` implementation. But since this may break builds in unintended ways.

Fixes: https://github.com/trs/ftp-srv/issues/90