### PR TITLE
fix(connector): build passive server correctly for tls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ class FtpServer extends EventEmitter {
       return connection.reply(220, ...greeting, features)
       .finally(() => socket.resume());
     };
-    const serverOptions = _.assign(this.isTLS ? this._tls : {}, {pauseOnConnect: true});
+    const serverOptions = Object.assign({}, this.isTLS ? this._tls : {}, {pauseOnConnect: true});
 
     this.server = (this.isTLS ? tls : net).createServer(serverOptions, serverConnectionHandler);
     this.server.on('error', err => this.log.error(err, '[Event] error'));

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -385,7 +385,7 @@ describe('Integration', function () {
     runFileSystemTests('binary');
   });
 
-  describe.skip('#EXPLICIT', function () {
+  describe('#EXPLICIT', function () {
     before(() => {
       return server.close()
       .then(() => startServer('ftp://127.0.0.1:8880', {


### PR DESCRIPTION
Fixes an issue where passive TLS connections would never be fulfilled.

This uses `tls` to create a server if the connection is secure instead of upgrading an already connected socket.

Fixes:
- https://github.com/trs/ftp-srv/issues/96