### PR TITLE
FIX: PASV mode port finder would always start on the same port as the generator was recreated every time

### DIFF
--- a/src/helpers/find-port.js
+++ b/src/helpers/find-port.js
@@ -12,8 +12,12 @@ function* portNumberGenerator(min, max) {
   }
 }
 
+let nextPortNumber;
+
 function getNextPortFactory(min, max = Infinity) {
-  let nextPortNumber = portNumberGenerator(min, max);
+  if (!nextPortNumber) {
+    nextPortNumber = portNumberGenerator(min, max);
+  }
   let portCheckServer = net.createServer();
   portCheckServer.maxConnections = 0;
   portCheckServer.on('error', () => {


### PR DESCRIPTION
Reuse the Port Number Generator