### PR TITLE
 fix(stor): use the close event

### DIFF
--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -37,7 +37,7 @@ module.exports = {
             stream.write(data, this.transferType, () => this.connector.socket && this.connector.socket.resume());
           }
         });
-        this.connector.socket.once('end', () => {
+        this.connector.socket.once('close', () => {
           if (stream.listenerCount('close')) stream.emit('close');
           else stream.end();
           resolve();


### PR DESCRIPTION
The 'end' event is not called when using tls. Use the 'close' event as it is called on both tls and non-tls sockets.

Not sure if this is a bug with nodejs (Using v8.11.2)

