### PR TITLE
(fix) base: set datasocket to null once destroyed

### DIFF
--- a/src/connector/base.js
+++ b/src/connector/base.js
@@ -30,6 +30,7 @@ class Connector {
     const closeDataSocket = new Promise(resolve => {
       if (this.dataSocket) {
         this.dataSocket.end().destroy();
+        this.dataSocket = null;
       }
 
       resolve();


### PR DESCRIPTION
Ensure new sockets get created when uploading files by setting the datasocket to null after its destroyed