### PR TITLE
fix: command parse ignores flags on RETR and SIZE

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -14,8 +14,9 @@ class FtpCommands {
   parse(message) {
     const strippedMessage = message.replace(/"/g, '');
     const [directive, ...args] = strippedMessage.split(' ');
+    const hasFlags = !['RETR', 'SIZE'].includes(directive);
     const params = args.reduce(({arg, flags}, param) => {
-      if (/^-{1,2}[a-zA-Z0-9_]+/.test(param)) flags.push(param);
+      if (hasFlags && /^-{1,2}[a-zA-Z0-9_]+/.test(param)) flags.push(param);
       else arg.push(param);
       return {arg, flags};
     }, {arg: [], flags: []});

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -13,16 +13,18 @@ class FtpCommands {
 
   parse(message) {
     const strippedMessage = message.replace(/"/g, '');
-    const [directive, ...args] = strippedMessage.split(' ');
-    const hasFlags = !['RETR', 'SIZE'].includes(directive);
+    let [directive, ...args] = strippedMessage.split(' ');
+    directive = _.chain(directive).trim().toUpper().value();
+
+    const parseCommandFlags = !['RETR', 'SIZE'].includes(directive);
     const params = args.reduce(({arg, flags}, param) => {
-      if (hasFlags && /^-{1,2}[a-zA-Z0-9_]+/.test(param)) flags.push(param);
+      if (parseCommandFlags && /^-{1,2}[a-zA-Z0-9_]+/.test(param)) flags.push(param);
       else arg.push(param);
       return {arg, flags};
     }, {arg: [], flags: []});
 
     const command = {
-      directive: _.chain(directive).trim().toUpper().value(),
+      directive,
       arg: params.arg.length ? params.arg.join(' ') : null,
       flags: params.flags,
       raw: message

--- a/test/commands/index.spec.js
+++ b/test/commands/index.spec.js
@@ -76,6 +76,13 @@ describe('FtpCommands', function () {
       expect(cmd.flags).to.deep.equal(['-l']);
       expect(cmd.raw).to.equal('list -l');
     });
+
+    it('does not check for option flags', () => {
+      const cmd = commands.parse('retr -test');
+      expect(cmd.directive).to.equal('RETR');
+      expect(cmd.arg).to.equal('-test');
+      expect(cmd.flags).to.deep.equal([]);
+    });
   });
 
   describe('handle', function () {


### PR DESCRIPTION
Attempting action on files that start with `-` causes the server to fail.
These commands do not accept flags, so don't attempt parsing them

https://github.com/trs/ftp-srv/issues/120