### PR TITLE
(fix): timeouts when using tls

### DIFF
--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -40,7 +40,7 @@ module.exports = {
             stream.write(data, this.transferType, () => this.connector.socket && this.connector.socket.resume());
           }
         });
-        this.connector.socket.once('close', () => {
+        this.connector.socket.once('end', () => {
           if (stream.listenerCount('close')) stream.emit('close');
           else stream.end();
           resolve();

--- a/src/connector/base.js
+++ b/src/connector/base.js
@@ -26,7 +26,7 @@ class Connector {
     return Promise.reject(new errors.ConnectorError('No connector setup, send PASV or PORT'));
   }
 
-  end() {
+  closeSocket() {
     const closeDataSocket = new Promise(resolve => {
       if (this.dataSocket) {
         this.dataSocket.end().destroy();
@@ -34,16 +34,30 @@ class Connector {
       }
       resolve();
     });
+
+    return closeDataSocket;
+  }
+    
+  closeServer() {
     const closeDataServer = new Promise(resolve => {
       if (this.dataServer) {
-        this.dataServer.close(() => resolve());
-      } else resolve();
+        this.dataServer.close();
+        this.dataServer = null;
+      }
+      resolve();
     });
+
+    return closeDataServer;
+  }
+
+      
+  end() {
+    const closeDataSocket = this.closeSocket();
+
+    const closeDataServer = this.closeServer();
 
     return Promise.all([closeDataSocket, closeDataServer])
     .then(() => {
-      this.dataSocket = null;
-      this.dataServer = null;
       this.type = false;
 
       this.connection.connector = new Connector(this);

--- a/src/connector/passive.js
+++ b/src/connector/passive.js
@@ -12,7 +12,7 @@ class Passive extends Connector {
     this.type = 'passive';
   }
 
-  waitForConnection({timeout = 5000, delay = 250} = {}) {
+  waitForConnection({timeout = 5000, delay = 50} = {}) {
     if (!this.dataServer) return Promise.reject(new errors.ConnectorError('Passive server not setup'));
 
     const checkSocket = () => {
@@ -27,9 +27,7 @@ class Passive extends Connector {
   }
 
   setupServer() {
-    const closeExistingServer = () => this.dataServer ?
-      new Promise(resolve => this.dataServer.close(() => resolve())) :
-      Promise.resolve();
+    const closeExistingServer = () => this.closeServer();
 
     return closeExistingServer()
     .then(() => this.server.getNextPasvPort())
@@ -48,13 +46,10 @@ class Passive extends Connector {
         this.log.trace({port, remoteAddress: socket.remoteAddress}, 'Passive connection fulfilled.');
 
         this.dataSocket = socket;
-        this.dataSocket.connected = true;
+        
         this.dataSocket.setEncoding(this.connection.transferType);
         this.dataSocket.on('error', err => this.server && this.server.emit('client-error', {connection: this.connection, context: 'dataSocket', error: err}));
-        this.dataSocket.once('close', () => {
-          this.log.trace('Passive connection closed');
-          this.end();
-        });
+
       };
 
       this.dataSocket = null;
@@ -68,6 +63,10 @@ class Passive extends Connector {
         this.log.trace('Passive server closed');
         this.end();
       });
+      this.dataServer.on('secureConnection', (socket) => {
+        socket.connected = true;  
+      });
+
 
       return new Promise((resolve, reject) => {
         this.dataServer.listen(port, this.server.url.hostname, err => {


### PR DESCRIPTION
Seemed to be a collection of issues there were all combining to cause this.

1. Use the 'end' event instead of the close event
2. Use the correct events when waiting for a passive connection to be established
3. Dont close the sockets so aggressively

@trs Appreciate a review here, there was a lot of trial and error to get this fix working. You might spot a few improvements