### PR TITLE
fix: correct timeouts around TLS data connection

### DIFF
--- a/config/verify/.eslintrc
+++ b/config/verify/.eslintrc
@@ -136,7 +136,7 @@
     "comma-dangle": 1,
     "new-cap": 2,
     "new-parens": 2,
-    "arrow-parens": [2, "as-needed"],
+    "arrow-parens": [2, "always"],
     "no-array-constructor": 2,
     "array-callback-return": 1,
     "no-extra-parens": 2,

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -9,8 +9,8 @@ class FtpCommands {
   constructor(connection) {
     this.connection = connection;
     this.previousCommand = {};
-    this.blacklist = _.get(this.connection, 'server.options.blacklist', []).map(cmd => _.upperCase(cmd));
-    this.whitelist = _.get(this.connection, 'server.options.whitelist', []).map(cmd => _.upperCase(cmd));
+    this.blacklist = _.get(this.connection, 'server.options.blacklist', []).map((cmd) => _.upperCase(cmd));
+    this.whitelist = _.get(this.connection, 'server.options.whitelist', []).map((cmd) => _.upperCase(cmd));
   }
 
   parse(message) {

--- a/src/commands/registration/abor.js
+++ b/src/commands/registration/abor.js
@@ -2,7 +2,7 @@ module.exports = {
   directive: 'ABOR',
   handler: function () {
     return this.connector.waitForConnection()
-    .then(socket => {
+    .then((socket) => {
       return this.reply(426, {socket})
       .then(() => this.reply(226));
     })

--- a/src/commands/registration/auth.js
+++ b/src/commands/registration/auth.js
@@ -30,7 +30,7 @@ function handleTLS() {
       isServer: true,
       secureContext
     });
-    ['data', 'timeout', 'end', 'close', 'drain', 'error'].forEach(event => {
+    ['data', 'timeout', 'end', 'close', 'drain', 'error'].forEach((event) => {
       function forwardEvent() {
         this.emit.apply(this, arguments);
       }

--- a/src/commands/registration/cwd.js
+++ b/src/commands/registration/cwd.js
@@ -8,11 +8,11 @@ module.exports = {
     if (!this.fs.chdir) return this.reply(402, 'Not supported by file system');
 
     return Promise.try(() => this.fs.chdir(command.arg))
-    .then(cwd => {
+    .then((cwd) => {
       const path = cwd ? `"${escapePath(cwd)}"` : undefined;
       return this.reply(250, path);
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(550, err.message);
     });

--- a/src/commands/registration/dele.js
+++ b/src/commands/registration/dele.js
@@ -10,7 +10,7 @@ module.exports = {
     .then(() => {
       return this.reply(250);
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(550, err.message);
     });

--- a/src/commands/registration/epsv.js
+++ b/src/commands/registration/epsv.js
@@ -5,7 +5,7 @@ module.exports = {
   handler: function () {
     this.connector = new PassiveConnector(this);
     return this.connector.setupServer()
-    .then(server => {
+    .then((server) => {
       const {port} = server.address();
 
       return this.reply(229, `EPSV OK (|||${port}|)`);

--- a/src/commands/registration/feat.js
+++ b/src/commands/registration/feat.js
@@ -11,7 +11,7 @@ module.exports = {
         return feats;
       }, ['UTF8'])
       .sort()
-      .map(feat => ({
+      .map((feat) => ({
         message: ` ${feat}`,
         raw: true
       }));

--- a/src/commands/registration/help.js
+++ b/src/commands/registration/help.js
@@ -12,7 +12,7 @@ module.exports = {
       const reply = _.concat([syntax.replace('{{cmd}}', directive), description]);
       return this.reply(214, ...reply);
     } else {
-      const supportedCommands = _.chunk(Object.keys(registry), 5).map(chunk => chunk.join('\t'));
+      const supportedCommands = _.chunk(Object.keys(registry), 5).map((chunk) => chunk.join('\t'));
       return this.reply(211, 'Supported commands:', ...supportedCommands, 'Use "HELP [command]" for syntax help.');
     }
   },

--- a/src/commands/registration/list.js
+++ b/src/commands/registration/list.js
@@ -17,14 +17,14 @@ module.exports = {
     return this.connector.waitForConnection()
     .tap(() => this.commandSocket.pause())
     .then(() => Promise.try(() => this.fs.get(path)))
-    .then(stat => stat.isDirectory() ? Promise.try(() => this.fs.list(path)) : [stat])
-    .then(files => {
-      const getFileMessage = file => {
+    .then((stat) => stat.isDirectory() ? Promise.try(() => this.fs.list(path)) : [stat])
+    .then((files) => {
+      const getFileMessage = (file) => {
         if (simple) return file.name;
         return getFileStat(file, _.get(this, 'server.options.file_format', 'ls'));
       };
 
-      return Promise.try(() => files.map(file => {
+      return Promise.try(() => files.map((file) => {
         const message = getFileMessage(file);
         return {
           raw: true,
@@ -34,15 +34,15 @@ module.exports = {
       }));
     })
     .tap(() => this.reply(150))
-    .then(fileList => {
+    .then((fileList) => {
       if (fileList.length) return this.reply({}, ...fileList);
     })
     .tap(() => this.reply(226))
-    .catch(Promise.TimeoutError, err => {
+    .catch(Promise.TimeoutError, (err) => {
       log.error(err);
       return this.reply(425, 'No connection established');
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(451, err.message || 'No directory');
     })

--- a/src/commands/registration/list.js
+++ b/src/commands/registration/list.js
@@ -46,7 +46,10 @@ module.exports = {
       log.error(err);
       return this.reply(451, err.message || 'No directory');
     })
-    .finally(() => this.connector.end().then(() => this.commandSocket.resume()));
+    .finally(() => {
+      this.connector.end();
+      this.commandSocket.resume();
+    });
   },
   syntax: '{{cmd}} [<path>]',
   description: 'Returns information of a file or directory if specified, else information of the current working directory is returned'

--- a/src/commands/registration/mdtm.js
+++ b/src/commands/registration/mdtm.js
@@ -8,11 +8,11 @@ module.exports = {
     if (!this.fs.get) return this.reply(402, 'Not supported by file system');
 
     return Promise.try(() => this.fs.get(command.arg))
-    .then(fileStat => {
+    .then((fileStat) => {
       const modificationTime = moment.utc(fileStat.mtime).format('YYYYMMDDHHmmss.SSS');
       return this.reply(213, modificationTime);
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(550, err.message);
     });

--- a/src/commands/registration/mkd.js
+++ b/src/commands/registration/mkd.js
@@ -8,11 +8,11 @@ module.exports = {
     if (!this.fs.mkdir) return this.reply(402, 'Not supported by file system');
 
     return Promise.try(() => this.fs.mkdir(command.arg))
-    .then(dir => {
+    .then((dir) => {
       const path = dir ? `"${escapePath(dir)}"` : undefined;
       return this.reply(257, path);
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(550, err.message);
     });

--- a/src/commands/registration/pass.js
+++ b/src/commands/registration/pass.js
@@ -12,7 +12,7 @@ module.exports = {
     .then(() => {
       return this.reply(230);
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(530, err.message || 'Authentication failed');
     });

--- a/src/commands/registration/pasv.js
+++ b/src/commands/registration/pasv.js
@@ -5,7 +5,7 @@ module.exports = {
   handler: function () {
     this.connector = new PassiveConnector(this);
     return this.connector.setupServer()
-    .then(server => {
+    .then((server) => {
       const address = this.server.options.pasv_url;
       const {port} = server.address();
       const host = address.replace(/\./g, ',');

--- a/src/commands/registration/port.js
+++ b/src/commands/registration/port.js
@@ -10,7 +10,7 @@ module.exports = {
     if (rawConnection.length !== 6) return this.reply(425);
 
     const ip = rawConnection.slice(0, 4).join('.');
-    const portBytes = rawConnection.slice(4).map(p => parseInt(p));
+    const portBytes = rawConnection.slice(4).map((p) => parseInt(p));
     const port = portBytes[0] * 256 + portBytes[1];
 
     return this.connector.setupConnection(ip, port)

--- a/src/commands/registration/pwd.js
+++ b/src/commands/registration/pwd.js
@@ -8,11 +8,11 @@ module.exports = {
     if (!this.fs.currentDirectory) return this.reply(402, 'Not supported by file system');
 
     return Promise.try(() => this.fs.currentDirectory())
-    .then(cwd => {
+    .then((cwd) => {
       const path = cwd ? `"${escapePath(cwd)}"` : undefined;
       return this.reply(257, path);
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(550, err.message);
     });

--- a/src/commands/registration/retr.js
+++ b/src/commands/registration/retr.js
@@ -11,7 +11,7 @@ module.exports = {
     return this.connector.waitForConnection()
     .tap(() => this.commandSocket.pause())
     .then(() => Promise.try(() => this.fs.read(filePath, {start: this.restByteCount})))
-    .then(fsResponse => {
+    .then((fsResponse) => {
       let {stream, clientPath} = fsResponse;
       if (!stream && !clientPath) {
         stream = fsResponse;
@@ -19,13 +19,13 @@ module.exports = {
       }
       const serverPath = stream.path || filePath;
 
-      const destroyConnection = (connection, reject) => err => {
+      const destroyConnection = (connection, reject) => (err) => {
         if (connection) connection.destroy(err);
         reject(err);
       };
 
       const eventsPromise = new Promise((resolve, reject) => {
-        stream.on('data', data => {
+        stream.on('data', (data) => {
           if (stream) stream.pause();
           if (this.connector.socket) {
             this.connector.socket.write(data, this.transferType, () => stream && stream.resume());
@@ -45,11 +45,11 @@ module.exports = {
       .then(() => this.reply(226, clientPath))
       .finally(() => stream.destroy && stream.destroy());
     })
-    .catch(Promise.TimeoutError, err => {
+    .catch(Promise.TimeoutError, (err) => {
       log.error(err);
       return this.reply(425, 'No connection established');
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       this.emit('RETR', err);
       return this.reply(551, err.message);

--- a/src/commands/registration/retr.js
+++ b/src/commands/registration/retr.js
@@ -54,7 +54,10 @@ module.exports = {
       this.emit('RETR', err);
       return this.reply(551, err.message);
     })
-    .finally(() => this.connector.end().then(() => this.commandSocket.resume()));
+    .finally(() => {
+      this.connector.end();
+      this.commandSocket.resume();
+    });
   },
   syntax: '{{cmd}} <path>',
   description: 'Retrieve a copy of the file'

--- a/src/commands/registration/rnfr.js
+++ b/src/commands/registration/rnfr.js
@@ -12,7 +12,7 @@ module.exports = {
       this.renameFrom = fileName;
       return this.reply(350);
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(550, err.message);
     });

--- a/src/commands/registration/rnto.js
+++ b/src/commands/registration/rnto.js
@@ -15,7 +15,7 @@ module.exports = {
     .then(() => {
       return this.reply(250);
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(550, err.message);
     })

--- a/src/commands/registration/site/chmod.js
+++ b/src/commands/registration/site/chmod.js
@@ -10,7 +10,7 @@ module.exports = function ({log, command} = {}) {
   .then(() => {
     return this.reply(200);
   })
-  .catch(err => {
+  .catch((err) => {
     log.error(err);
     return this.reply(500);
   });

--- a/src/commands/registration/size.js
+++ b/src/commands/registration/size.js
@@ -7,10 +7,10 @@ module.exports = {
     if (!this.fs.get) return this.reply(402, 'Not supported by file system');
 
     return Promise.try(() => this.fs.get(command.arg))
-    .then(fileStat => {
+    .then((fileStat) => {
       return this.reply(213, {message: fileStat.size});
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       return this.reply(550, err.message);
     });

--- a/src/commands/registration/stat.js
+++ b/src/commands/registration/stat.js
@@ -12,27 +12,27 @@ module.exports = {
       if (!this.fs.get) return this.reply(402, 'Not supported by file system');
 
       return Promise.try(() => this.fs.get(path))
-      .then(stat => {
+      .then((stat) => {
         if (stat.isDirectory()) {
           if (!this.fs.list) return this.reply(402, 'Not supported by file system');
 
           return Promise.try(() => this.fs.list(path))
-          .then(stats => [213, stats]);
+          .then((stats) => [213, stats]);
         }
         return [212, [stat]];
       })
       .then(([code, fileStats]) => {
-        return Promise.map(fileStats, file => {
+        return Promise.map(fileStats, (file) => {
           const message = getFileStat(file, _.get(this, 'server.options.file_format', 'ls'));
           return {
             raw: true,
             message
           };
         })
-        .then(messages => [code, messages]);
+        .then((messages) => [code, messages]);
       })
       .then(([code, messages]) => this.reply(code, 'Status begin', ...messages, 'Status end'))
-      .catch(err => {
+      .catch((err) => {
         log.error(err);
         return this.reply(450, err.message);
       });

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -12,7 +12,7 @@ module.exports = {
     return this.connector.waitForConnection()
     .tap(() => this.commandSocket.pause())
     .then(() => Promise.try(() => this.fs.write(fileName, {append, start: this.restByteCount})))
-    .then(fsResponse => {
+    .then((fsResponse) => {
       let {stream, clientPath} = fsResponse;
       if (!stream && !clientPath) {
         stream = fsResponse;
@@ -20,7 +20,7 @@ module.exports = {
       }
       const serverPath = stream.path || fileName;
 
-      const destroyConnection = (connection, reject) => err => {
+      const destroyConnection = (connection, reject) => (err) => {
         if (connection) {
           if (connection.writeable) connection.end();
           connection.destroy(err);
@@ -34,7 +34,7 @@ module.exports = {
       });
 
       const socketPromise = new Promise((resolve, reject) => {
-        this.connector.socket.on('data', data => {
+        this.connector.socket.on('data', (data) => {
           if (this.connector.socket) this.connector.socket.pause();
           if (stream) {
             stream.write(data, this.transferType, () => this.connector.socket && this.connector.socket.resume());
@@ -56,11 +56,11 @@ module.exports = {
       .then(() => this.reply(226, clientPath))
       .finally(() => stream.destroy && stream.destroy());
     })
-    .catch(Promise.TimeoutError, err => {
+    .catch(Promise.TimeoutError, (err) => {
       log.error(err);
       return this.reply(425, 'No connection established');
     })
-    .catch(err => {
+    .catch((err) => {
       log.error(err);
       this.emit('STOR', err);
       return this.reply(550, err.message);

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -65,7 +65,10 @@ module.exports = {
       this.emit('STOR', err);
       return this.reply(550, err.message);
     })
-    .finally(() => this.connector.end().then(() => this.commandSocket.resume()));
+    .finally(() => {
+      this.connector.end();
+      this.commandSocket.resume();
+    });
   },
   syntax: '{{cmd}} <path>',
   description: 'Store data as a file at the server site'

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -40,7 +40,7 @@ module.exports = {
             stream.write(data, this.transferType, () => this.connector.socket && this.connector.socket.resume());
           }
         });
-        this.connector.socket.once('close', () => {
+        this.connector.socket.once('end', () => {
           if (stream.listenerCount('close')) stream.emit('close');
           else stream.end();
           resolve();

--- a/src/commands/registration/stou.js
+++ b/src/commands/registration/stou.js
@@ -11,7 +11,7 @@ module.exports = {
     return Promise.try(() => this.fs.get(fileName))
     .then(() => Promise.try(() => this.fs.getUniqueName()))
     .catch(() => fileName)
-    .then(name => {
+    .then((name) => {
       args.command.arg = name;
       return stor.call(this, args);
     });

--- a/src/commands/registration/user.js
+++ b/src/commands/registration/user.js
@@ -13,7 +13,7 @@ module.exports = {
       .then(() => {
         return this.reply(230);
       })
-      .catch(err => {
+      .catch((err) => {
         log.error(err);
         return this.reply(530, err.message || 'Authentication failed');
       });

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -43,7 +43,7 @@ const commands = [
 
 const registry = commands.reduce((result, cmd) => {
   const aliases = Array.isArray(cmd.directive) ? cmd.directive : [cmd.directive];
-  aliases.forEach(alias => result[alias] = cmd);
+  aliases.forEach((alias) => result[alias] = cmd);
   return result;
 }, {});
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -25,7 +25,7 @@ class FtpConnection extends EventEmitter {
     this.connector = new BaseConnector(this);
 
     this.commandSocket = options.socket;
-    this.commandSocket.on('error', err => {
+    this.commandSocket.on('error', (err) => {
       this.log.error(err, 'Client error');
       this.server.emit('client-error', {connection: this, context: 'commandSocket', error: err});
     });
@@ -41,7 +41,7 @@ class FtpConnection extends EventEmitter {
   _handleData(data) {
     const messages = _.compact(data.toString(this.encoding).split('\r\n'));
     this.log.trace(messages);
-    return Promise.mapSeries(messages, message => this.commands.handle(message));
+    return Promise.mapSeries(messages, (message) => this.commands.handle(message));
   }
 
   get ip() {
@@ -68,7 +68,7 @@ class FtpConnection extends EventEmitter {
 
   close(code = 421, message = 'Closing connection') {
     return Promise.resolve(code)
-      .then(_code => _code && this.reply(_code, message))
+      .then((_code) => _code && this.reply(_code, message))
       .then(() => this.commandSocket && this.commandSocket.end());
   }
 
@@ -96,7 +96,7 @@ class FtpConnection extends EventEmitter {
       if (!letters.length) letters = [{}];
       return Promise.map(letters, (promise, index) => {
         return Promise.resolve(promise)
-        .then(letter => {
+        .then((letter) => {
           if (!letter) letter = {};
           else if (typeof letter === 'string') letter = {message: letter}; // allow passing in message as first param
 
@@ -104,7 +104,7 @@ class FtpConnection extends EventEmitter {
           if (!letter.message) letter.message = DEFAULT_MESSAGE[options.code] || 'No information';
           if (!letter.encoding) letter.encoding = this.encoding;
           return Promise.resolve(letter.message) // allow passing in a promise as a message
-          .then(message => {
+          .then((message) => {
             const seperator = !options.hasOwnProperty('eol') ?
               letters.length - 1 === index ? ' ' : '-' :
               options.eol ? ' ' : '-';
@@ -116,11 +116,11 @@ class FtpConnection extends EventEmitter {
       });
     };
 
-    const processLetter = letter => {
+    const processLetter = (letter) => {
       return new Promise((resolve, reject) => {
         if (letter.socket && letter.socket.writable) {
           this.log.trace({port: letter.socket.address().port, encoding: letter.encoding, message: letter.message}, 'Reply');
-          letter.socket.write(letter.message + '\r\n', letter.encoding, err => {
+          letter.socket.write(letter.message + '\r\n', letter.encoding, (err) => {
             if (err) {
               this.log.error(err);
               return reject(err);
@@ -132,10 +132,10 @@ class FtpConnection extends EventEmitter {
     };
 
     return satisfyParameters()
-    .then(satisfiedLetters => Promise.mapSeries(satisfiedLetters, (letter, index) => {
+    .then((satisfiedLetters) => Promise.mapSeries(satisfiedLetters, (letter, index) => {
       return processLetter(letter, index);
     }))
-    .catch(err => {
+    .catch((err) => {
       this.log.error(err);
     });
   }

--- a/src/connector/active.js
+++ b/src/connector/active.js
@@ -29,7 +29,7 @@ class Active extends Connector {
     .then(() => {
       this.dataSocket = new Socket();
       this.dataSocket.setEncoding(this.connection.transferType);
-      this.dataSocket.on('error', err => this.server && this.server.emit('client-error', {connection: this.connection, context: 'dataSocket', error: err}));
+      this.dataSocket.on('error', (err) => this.server && this.server.emit('client-error', {connection: this.connection, context: 'dataSocket', error: err}));
       this.dataSocket.connect({host, port, family}, () => {
         this.dataSocket.pause();
 

--- a/src/connector/base.js
+++ b/src/connector/base.js
@@ -26,7 +26,7 @@ class Connector {
     return Promise.reject(new errors.ConnectorError('No connector setup, send PASV or PORT'));
   }
 
-  end() {
+  closeSocket() {
     const closeDataSocket = new Promise(resolve => {
       if (this.dataSocket) {
         this.dataSocket.end().destroy();
@@ -34,16 +34,30 @@ class Connector {
       }
       resolve();
     });
+
+    return closeDataSocket;
+  }
+    
+  closeServer() {
     const closeDataServer = new Promise(resolve => {
       if (this.dataServer) {
-        this.dataServer.close(() => resolve());
-      } else resolve();
+        this.dataServer.close();
+        this.dataServer = null;
+      }
+      resolve();
     });
+
+    return closeDataServer;
+  }
+
+      
+  end() {
+    const closeDataSocket = this.closeSocket();
+
+    const closeDataServer = this.closeServer();
 
     return Promise.all([closeDataSocket, closeDataServer])
     .then(() => {
-      this.dataSocket = null;
-      this.dataServer = null;
       this.type = false;
 
       this.connection.connector = new Connector(this);

--- a/src/connector/base.js
+++ b/src/connector/base.js
@@ -27,36 +27,27 @@ class Connector {
   }
 
   closeSocket() {
-    const closeDataSocket = new Promise(resolve => {
+    return new Promise((resolve) => {
       if (this.dataSocket) {
         this.dataSocket.end().destroy();
         this.dataSocket = null;
       }
       resolve();
     });
-
-    return closeDataSocket;
   }
-    
+
   closeServer() {
-    const closeDataServer = new Promise(resolve => {
+    return new Promise((resolve) => {
       if (this.dataServer) {
-        this.dataServer.close();
+        this.dataServer.close(() => resolve());
         this.dataServer = null;
-      }
-      resolve();
+      } else resolve();
     });
-
-    return closeDataServer;
   }
 
-      
+
   end() {
-    const closeDataSocket = this.closeSocket();
-
-    const closeDataServer = this.closeServer();
-
-    return Promise.all([closeDataSocket, closeDataServer])
+    return Promise.all([this.closeSocket(), this.closeServer()])
     .then(() => {
       this.type = false;
 

--- a/src/connector/base.js
+++ b/src/connector/base.js
@@ -27,35 +27,27 @@ class Connector {
   }
 
   closeSocket() {
-    return new Promise((resolve) => {
-      if (this.dataSocket) {
-        const socket = this.dataSocket;
-        this.dataSocket.end(() => {
-          socket.destroy();
-          resolve();
-        });
-        this.dataSocket = null;
-      } else resolve();
-    });
+    if (this.dataSocket) {
+      const socket = this.dataSocket;
+      this.dataSocket.end(() => socket.destroy());
+      this.dataSocket = null;
+    }
   }
 
   closeServer() {
-    return new Promise((resolve) => {
-      if (this.dataServer) {
-        this.dataServer.close(() => resolve());
-        this.dataServer = null;
-      } else resolve();
-    });
+    if (this.dataServer) {
+      this.dataServer.close();
+      this.dataServer = null;
+    }
   }
 
 
   end() {
-    return Promise.all([this.closeSocket(), this.closeServer()])
-    .then(() => {
-      this.type = false;
+    this.closeSocket();
+    this.closeServer();
 
-      this.connection.connector = new Connector(this);
-    });
+    this.type = false;
+    this.connection.connector = new Connector(this);
   }
 }
 module.exports = Connector;

--- a/src/connector/base.js
+++ b/src/connector/base.js
@@ -29,10 +29,13 @@ class Connector {
   closeSocket() {
     return new Promise((resolve) => {
       if (this.dataSocket) {
-        this.dataSocket.end().destroy();
+        const socket = this.dataSocket;
+        this.dataSocket.end(() => {
+          socket.destroy();
+          resolve();
+        });
         this.dataSocket = null;
-      }
-      resolve();
+      } else resolve();
     });
   }
 

--- a/src/connector/passive.js
+++ b/src/connector/passive.js
@@ -12,7 +12,7 @@ class Passive extends Connector {
     this.type = 'passive';
   }
 
-  waitForConnection({timeout = 5000, delay = 250} = {}) {
+  waitForConnection({timeout = 5000, delay = 50} = {}) {
     if (!this.dataServer) return Promise.reject(new errors.ConnectorError('Passive server not setup'));
 
     const checkSocket = () => {
@@ -27,9 +27,7 @@ class Passive extends Connector {
   }
 
   setupServer() {
-    const closeExistingServer = () => this.dataServer ?
-      new Promise(resolve => this.dataServer.close(() => resolve())) :
-      Promise.resolve();
+    const closeExistingServer = () => this.closeServer();
 
     return closeExistingServer()
     .then(() => this.server.getNextPasvPort())
@@ -48,13 +46,10 @@ class Passive extends Connector {
         this.log.trace({port, remoteAddress: socket.remoteAddress}, 'Passive connection fulfilled.');
 
         this.dataSocket = socket;
-        this.dataSocket.connected = true;
+        
         this.dataSocket.setEncoding(this.connection.transferType);
         this.dataSocket.on('error', err => this.server && this.server.emit('client-error', {connection: this.connection, context: 'dataSocket', error: err}));
-        this.dataSocket.once('close', () => {
-          this.log.trace('Passive connection closed');
-          this.end();
-        });
+
       };
 
       this.dataSocket = null;
@@ -68,6 +63,10 @@ class Passive extends Connector {
         this.log.trace('Passive server closed');
         this.end();
       });
+      this.dataServer.on('secureConnection', (socket) => {
+        socket.connected = true;  
+      });
+
 
       return new Promise((resolve, reject) => {
         this.dataServer.listen(port, this.server.url.hostname, err => {

--- a/src/connector/passive.js
+++ b/src/connector/passive.js
@@ -27,10 +27,8 @@ class Passive extends Connector {
   }
 
   setupServer() {
-    const closeExistingServer = () => this.closeServer();
-
-    return closeExistingServer()
-    .then(() => this.server.getNextPasvPort())
+    this.closeServer();
+    return this.server.getNextPasvPort()
     .then((port) => {
       const connectionHandler = (socket) => {
         if (!ip.isEqual(this.connection.commandSocket.remoteAddress, socket.remoteAddress)) {

--- a/src/connector/passive.js
+++ b/src/connector/passive.js
@@ -49,9 +49,9 @@ class Passive extends Connector {
         this.dataSocket.setEncoding(this.connection.transferType);
         this.dataSocket.on('error', (err) => this.server && this.server.emit('client-error', {connection: this.connection, context: 'dataSocket', error: err}));
 
-        // if (!this.connection.secure) {
-        //   this.dataSocket.connected = true;
-        // }
+        if (!this.connection.secure) {
+          this.dataSocket.connected = true;
+        }
       };
 
       this.dataSocket = null;

--- a/src/fs.js
+++ b/src/fs.js
@@ -44,19 +44,19 @@ class FileSystem {
   get(fileName) {
     const {fsPath} = this._resolvePath(fileName);
     return fs.statAsync(fsPath)
-    .then(stat => _.set(stat, 'name', fileName));
+    .then((stat) => _.set(stat, 'name', fileName));
   }
 
   list(path = '.') {
     const {fsPath} = this._resolvePath(path);
     return fs.readdirAsync(fsPath)
-    .then(fileNames => {
-      return Promise.map(fileNames, fileName => {
+    .then((fileNames) => {
+      return Promise.map(fileNames, (fileName) => {
         const filePath = nodePath.join(fsPath, fileName);
         return fs.accessAsync(filePath, fs.constants.F_OK)
         .then(() => {
           return fs.statAsync(filePath)
-          .then(stat => _.set(stat, 'name', fileName));
+          .then((stat) => _.set(stat, 'name', fileName));
         })
         .catch(() => null);
       });
@@ -67,7 +67,7 @@ class FileSystem {
   chdir(path = '.') {
     const {fsPath, clientPath} = this._resolvePath(path);
     return fs.statAsync(fsPath)
-    .tap(stat => {
+    .tap((stat) => {
       if (!stat.isDirectory()) throw new errors.FileSystemError('Not a valid directory');
     })
     .then(() => {
@@ -90,7 +90,7 @@ class FileSystem {
   read(fileName, {start = undefined} = {}) {
     const {fsPath, clientPath} = this._resolvePath(fileName);
     return fs.statAsync(fsPath)
-    .tap(stat => {
+    .tap((stat) => {
       if (stat.isDirectory()) throw new errors.FileSystemError('Cannot read a directory');
     })
     .then(() => {
@@ -105,7 +105,7 @@ class FileSystem {
   delete(path) {
     const {fsPath} = this._resolvePath(path);
     return fs.statAsync(fsPath)
-    .then(stat => {
+    .then((stat) => {
       if (stat.isDirectory()) return fs.rmdirAsync(fsPath);
       else return fs.unlinkAsync(fsPath);
     });

--- a/src/helpers/find-port.js
+++ b/src/helpers/find-port.js
@@ -20,14 +20,14 @@ function getNextPortFactory(min, max = Infinity) {
     portCheckServer.listen(nextPortNumber.next().value);
   });
 
-  return () => new Promise(resolve => {
+  return () => new Promise((resolve) => {
     portCheckServer.once('listening', () => {
       const {port} = portCheckServer.address();
       portCheckServer.close(() => resolve(port));
     });
     portCheckServer.listen(nextPortNumber.next().value);
   })
-  .catch(RangeError, err => Promise.reject(new errors.ConnectorError(err.message)));
+  .catch(RangeError, (err) => Promise.reject(new errors.ConnectorError(err.message)));
 }
 
 module.exports = {

--- a/src/helpers/resolve-host.js
+++ b/src/helpers/resolve-host.js
@@ -8,12 +8,12 @@ module.exports = function (hostname) {
   return new Promise((resolve, reject) => {
     if (!hostname || hostname === '0.0.0.0') {
       let ip = '';
-      http.get(IP_WEBSITE, response => {
+      http.get(IP_WEBSITE, (response) => {
         if (response.statusCode !== 200) {
           return reject(new errors.GeneralError('Unable to resolve hostname', response.statusCode));
         }
         response.setEncoding('utf8');
-        response.on('data', chunk => {
+        response.on('data', (chunk) => {
           ip += chunk;
         });
         response.on('end', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ class FtpServer extends EventEmitter {
       _.get(this, 'options.pasv_min'),
       _.get(this, 'options.pasv_max'));
 
-    const serverConnectionHandler = socket => {
+    const serverConnectionHandler = (socket) => {
       let connection = new Connection(this, {log: this.log, socket});
       this.connections[connection.id] = connection;
 
@@ -53,7 +53,7 @@ class FtpServer extends EventEmitter {
     const serverOptions = Object.assign({}, this.isTLS ? this.options.tls : {}, {pauseOnConnect: true});
 
     this.server = (this.isTLS ? tls : net).createServer(serverOptions, serverConnectionHandler);
-    this.server.on('error', err => this.log.error(err, '[Event] error'));
+    this.server.on('error', (err) => this.log.error(err, '[Event] error'));
 
     const quit = _.debounce(this.quit.bind(this), 100);
 
@@ -68,12 +68,12 @@ class FtpServer extends EventEmitter {
 
   listen() {
     return resolveHost(this.options.pasv_url || this.url.hostname)
-    .then(pasvUrl => {
+    .then((pasvUrl) => {
       this.options.pasv_url = pasvUrl;
 
       return new Promise((resolve, reject) => {
         this.server.once('error', reject);
-        this.server.listen(this.url.port, this.url.hostname, err => {
+        this.server.listen(this.url.port, this.url.hostname, (err) => {
           this.server.removeListener('error', reject);
           if (err) return reject(err);
           this.log.info({
@@ -112,7 +112,7 @@ class FtpServer extends EventEmitter {
   }
 
   disconnectClient(id) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       const client = this.connections[id];
       if (!client) return resolve();
       delete this.connections[id];
@@ -134,9 +134,9 @@ class FtpServer extends EventEmitter {
   close() {
     this.log.info('Server closing...');
     this.server.maxConnections = 0;
-    return Promise.map(Object.keys(this.connections), id => Promise.try(this.disconnectClient.bind(this, id)))
-    .then(() => new Promise(resolve => {
-      this.server.close(err => {
+    return Promise.map(Object.keys(this.connections), (id) => Promise.try(this.disconnectClient.bind(this, id)))
+    .then(() => new Promise((resolve) => {
+      this.server.close((err) => {
         if (err) this.log.error(err, 'Error closing server');
         resolve('Closed');
       });

--- a/test/commands/registration/retr.spec.js
+++ b/test/commands/registration/retr.spec.js
@@ -87,7 +87,7 @@ describe(CMD, function () {
     });
 
     let errorEmitted = false;
-    emitter.once('RETR', err => {
+    emitter.once('RETR', (err) => {
       errorEmitted = !!err;
     });
 

--- a/test/commands/registration/site/chmod.spec.js
+++ b/test/commands/registration/site/chmod.spec.js
@@ -23,7 +23,7 @@ describe(CMD, function () {
     sandbox.restore();
   });
 
-  it('// unsuccessful | no file system', done => {
+  it('// unsuccessful | no file system', (done) => {
     delete mockClient.fs;
 
     cmdFn()
@@ -34,7 +34,7 @@ describe(CMD, function () {
     .catch(done);
   });
 
-  it('// unsuccessful | file system does not have functions', done => {
+  it('// unsuccessful | file system does not have functions', (done) => {
     mockClient.fs = {};
 
     cmdFn()
@@ -45,7 +45,7 @@ describe(CMD, function () {
     .catch(done);
   });
 
-  it('777 test // unsuccessful | file chmod fails', done => {
+  it('777 test // unsuccessful | file chmod fails', (done) => {
     mockClient.fs.chmod.restore();
     sandbox.stub(mockClient.fs, 'chmod').rejects(new Error('test'));
 
@@ -57,7 +57,7 @@ describe(CMD, function () {
     .catch(done);
   });
 
-  it('777 test // successful', done => {
+  it('777 test // successful', (done) => {
     cmdFn({log: mockLog, command: {arg: '777 test'}})
     .then(() => {
       expect(mockClient.fs.chmod.args[0]).to.eql(['test', 511]);

--- a/test/commands/registration/stor.spec.js
+++ b/test/commands/registration/stor.spec.js
@@ -86,7 +86,7 @@ describe(CMD, function () {
     });
 
     let errorEmitted = false;
-    emitter.once('STOR', err => {
+    emitter.once('STOR', (err) => {
       errorEmitted = !!err;
     });
 

--- a/test/connector/active.spec.js
+++ b/test/connector/active.spec.js
@@ -19,18 +19,18 @@ describe('Connector - Active //', function () {
   before(() => {
     active = new ActiveConnector(mockConnection);
   });
-  beforeEach(done => {
+  beforeEach((done) => {
     sandbox = sinon.sandbox.create().usingPromise(Promise);
 
     getNextPort()
-    .then(port => {
+    .then((port) => {
       PORT = port;
       server = net.createServer()
-      .on('connection', socket => socket.destroy())
+      .on('connection', (socket) => socket.destroy())
       .listen(PORT, () => done());
     });
   });
-  afterEach(done => {
+  afterEach((done) => {
     sandbox.restore();
     server.close(done);
   });
@@ -58,7 +58,7 @@ describe('Connector - Active //', function () {
       expect(active.dataSocket).to.exist;
       return active.waitForConnection();
     })
-    .then(dataSocket => {
+    .then((dataSocket) => {
       expect(dataSocket.connected).to.equal(true);
       expect(dataSocket instanceof net.Socket).to.equal(true);
       expect(dataSocket instanceof tls.TLSSocket).to.equal(false);
@@ -78,7 +78,7 @@ describe('Connector - Active //', function () {
       expect(active.dataSocket).to.exist;
       return active.waitForConnection();
     })
-    .then(dataSocket => {
+    .then((dataSocket) => {
       expect(dataSocket.connected).to.equal(true);
       expect(dataSocket instanceof net.Socket).to.equal(true);
       expect(dataSocket instanceof tls.TLSSocket).to.equal(true);

--- a/test/connector/passive.spec.js
+++ b/test/connector/passive.spec.js
@@ -108,7 +108,7 @@ describe('Connector - Passive //', function () {
     it('destroys existing server, then sets up a server', function () {
       return passive.setupServer()
       .then(() => {
-        expect(closeFnSpy.callCount).to.equal(2);
+        expect(closeFnSpy.callCount).to.equal(1);
         expect(passive.dataServer).to.exist;
       });
     });
@@ -129,8 +129,8 @@ describe('Connector - Passive //', function () {
           expect(passive.connection.reply.callCount).to.equal(1);
           expect(passive.connection.reply.args[0][0]).to.equal(550);
 
-          passive.end()
-          .then(() => done());
+          passive.end();
+          done();
         }, 100);
       });
     })

--- a/test/connector/passive.spec.js
+++ b/test/connector/passive.spec.js
@@ -40,7 +40,7 @@ describe('Connector - Passive //', function () {
   it('cannot wait for connection with no server', function (done) {
     let passive = new PassiveConnector(mockConnection);
     passive.waitForConnection()
-    .catch(err => {
+    .catch((err) => {
       expect(err.name).to.equal('ConnectorError');
       done();
     });
@@ -54,7 +54,7 @@ describe('Connector - Passive //', function () {
     it('no pasv range provided', function (done) {
       let passive = new PassiveConnector(mockConnection);
       passive.setupServer()
-      .catch(err => {
+      .catch((err) => {
         try {
           expect(err.name).to.equal('ConnectorError');
           done();
@@ -75,7 +75,7 @@ describe('Connector - Passive //', function () {
 
     it('has invalid pasv range', function (done) {
       connection.setupServer()
-      .catch(err => {
+      .catch((err) => {
         expect(err.name).to.equal('ConnectorError');
         done();
       });

--- a/test/fs.spec.js
+++ b/test/fs.spec.js
@@ -28,7 +28,7 @@ describe('FileSystem', function () {
 
     it('handles error', function () {
       return Promise.try(() => ovFs.chdir())
-      .catch(err => {
+      .catch((err) => {
         expect(err).to.be.instanceof(errors.FileSystemError);
       });
     });

--- a/test/helpers/find-port.spec.js
+++ b/test/helpers/find-port.spec.js
@@ -25,7 +25,7 @@ describe('helpers // find-port', function () {
     });
 
     return getNextPort()
-    .then(port => {
+    .then((port) => {
       expect(port).to.equal(1);
     });
   });
@@ -37,15 +37,15 @@ describe('helpers // find-port', function () {
     });
 
     return getNextPort()
-    .then(port => {
+    .then((port) => {
       expect(port).to.equal(1);
     })
     .then(() => getNextPort())
-    .then(port => {
+    .then((port) => {
       expect(port).to.equal(2);
     })
     .then(() => getNextPort())
-    .then(port => {
+    .then((port) => {
       expect(port).to.equal(1);
     });
   });

--- a/test/helpers/resolve-host.spec.js
+++ b/test/helpers/resolve-host.spec.js
@@ -14,7 +14,7 @@ describe('helpers //resolve-host', function () {
   it('fetches ip address', () => {
     const hostname = '0.0.0.0';
     return resolveHost(hostname)
-    .then(resolvedHostname => {
+    .then((resolvedHostname) => {
       expect(resolvedHostname).to.match(/^\d+\.\d+\.\d+\.\d+$/);
     });
   });
@@ -22,7 +22,7 @@ describe('helpers //resolve-host', function () {
   it('fetches ip address', () => {
     const hostname = null;
     return resolveHost(hostname)
-    .then(resolvedHostname => {
+    .then((resolvedHostname) => {
       expect(resolvedHostname).to.match(/^\d+\.\d+\.\d+\.\d+$/);
     });
   });
@@ -30,7 +30,7 @@ describe('helpers //resolve-host', function () {
   it('does nothing', () => {
     const hostname = '127.0.0.1';
     return resolveHost(hostname)
-    .then(resolvedHostname => {
+    .then((resolvedHostname) => {
       expect(resolvedHostname).to.equal(hostname);
     });
   });
@@ -44,7 +44,7 @@ describe('helpers //resolve-host', function () {
 
     return resolveHost(null)
     .then(() => expect(1).to.equal(2))
-    .catch(err => {
+    .catch((err) => {
       expect(err.code).to.equal(420);
     });
   });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -64,7 +64,7 @@ describe('Integration', function () {
     return new Promise((resolve, reject) => {
       client = new FtpClient();
       client.once('ready', () => resolve(client));
-      client.once('error', err => reject(err));
+      client.once('error', (err) => reject(err));
       client.connect(_.assign({
         host: server.url.hostname,
         port: server.url.port,
@@ -72,7 +72,7 @@ describe('Integration', function () {
         password: 'test'
       }, options));
     })
-    .then(instance => {
+    .then((instance) => {
       client = instance;
     });
   }
@@ -80,8 +80,8 @@ describe('Integration', function () {
   function closeClient() {
     return new Promise((resolve, reject) => {
       client.once('close', () => resolve());
-      client.once('error', err => reject(err));
-      client.logout(err => {
+      client.once('error', (err) => reject(err));
+      client.logout((err) => {
         expect(err).to.be.undefined;
       });
     });
@@ -92,7 +92,7 @@ describe('Integration', function () {
     if (!dirExists) return;
 
     const list = fs.readdirSync(dir);
-    list.map(item => nodePath.resolve(dir, item)).forEach(item => {
+    list.map((item) => nodePath.resolve(dir, item)).forEach((item) => {
       const itemExists = fs.existsSync(dir);
       if (!itemExists) return;
 
@@ -113,7 +113,7 @@ describe('Integration', function () {
 
     after(() => directoryPurge(`${clientDirectory}/${name}/`));
 
-    it('STAT', done => {
+    it('STAT', (done) => {
       client.status((err, status) => {
         expect(err).to.not.exist;
         expect(status).to.equal('Status OK');
@@ -121,7 +121,7 @@ describe('Integration', function () {
       });
     });
 
-    it('SYST', done => {
+    it('SYST', (done) => {
       client.system((err, os) => {
         expect(err).to.not.exist;
         expect(os).to.equal('UNIX');
@@ -129,7 +129,7 @@ describe('Integration', function () {
       });
     });
 
-    it('CWD ..', done => {
+    it('CWD ..', (done) => {
       client.cwd('..', (err, data) => {
         expect(err).to.not.exist;
         expect(data).to.equal('/');
@@ -137,7 +137,7 @@ describe('Integration', function () {
       });
     });
 
-    it(`CWD ${name}`, done => {
+    it(`CWD ${name}`, (done) => {
       client.cwd(`${name}`, (err, data) => {
         expect(err).to.not.exist;
         expect(data).to.equal(`/${name}`);
@@ -145,7 +145,7 @@ describe('Integration', function () {
       });
     });
 
-    it('PWD', done => {
+    it('PWD', (done) => {
       client.pwd((err, data) => {
         expect(err).to.not.exist;
         expect(data).to.equal(`/${name}`);
@@ -153,7 +153,7 @@ describe('Integration', function () {
       });
     });
 
-    it('LIST .', done => {
+    it('LIST .', (done) => {
       client.list('.', (err, data) => {
         expect(err).to.not.exist;
         expect(data).to.be.an('array');
@@ -163,7 +163,7 @@ describe('Integration', function () {
       });
     });
 
-    it('LIST fake.txt', done => {
+    it('LIST fake.txt', (done) => {
       client.list('fake.txt', (err, data) => {
         expect(err).to.not.exist;
         expect(data).to.be.an('array');
@@ -173,7 +173,7 @@ describe('Integration', function () {
       });
     });
 
-    it('STOR fail.txt', done => {
+    it('STOR fail.txt', (done) => {
       const buffer = Buffer.from('test text file');
       const fsPath = `${clientDirectory}/${name}/fail.txt`;
 
@@ -185,7 +185,7 @@ describe('Integration', function () {
         return stream;
       });
 
-      client.put(buffer, 'fail.txt', err => {
+      client.put(buffer, 'fail.txt', (err) => {
         setImmediate(() => {
           const fileExists = fs.existsSync(fsPath);
           expect(err).to.exist;
@@ -195,15 +195,15 @@ describe('Integration', function () {
       });
     });
 
-    it('STOR tést.txt', done => {
+    it('STOR tést.txt', (done) => {
       const buffer = Buffer.from('test text file');
       const fsPath = `${clientDirectory}/${name}/tést.txt`;
 
-      connection.once('STOR', err => {
+      connection.once('STOR', (err) => {
         expect(err).to.not.exist;
       });
 
-      client.put(buffer, 'tést.txt', err => {
+      client.put(buffer, 'tést.txt', (err) => {
         expect(err).to.not.exist;
         setImmediate(() => {
           expect(fs.existsSync(fsPath)).to.equal(true);
@@ -216,10 +216,10 @@ describe('Integration', function () {
       });
     });
 
-    it('APPE tést.txt', done => {
+    it('APPE tést.txt', (done) => {
       const buffer = Buffer.from(', awesome!');
       const fsPath = `${clientDirectory}/${name}/tést.txt`;
-      client.append(buffer, 'tést.txt', err => {
+      client.append(buffer, 'tést.txt', (err) => {
         expect(err).to.not.exist;
         setImmediate(() => {
           expect(fs.existsSync(fsPath)).to.equal(true);
@@ -232,15 +232,15 @@ describe('Integration', function () {
       });
     });
 
-    it('RETR tést.txt', done => {
-      connection.once('RETR', err => {
+    it('RETR tést.txt', (done) => {
+      connection.once('RETR', (err) => {
         expect(err).to.not.exist;
       });
 
       client.get('tést.txt', (err, stream) => {
         expect(err).to.not.exist;
         let text = '';
-        stream.on('data', data => {
+        stream.on('data', (data) => {
           text += data.toString();
         });
         stream.on('end', () => {
@@ -251,8 +251,8 @@ describe('Integration', function () {
       });
     });
 
-    it('RNFR tést.txt, RNTO awesome.txt', done => {
-      client.rename('tést.txt', 'awesome.txt', err => {
+    it('RNFR tést.txt, RNTO awesome.txt', (done) => {
+      client.rename('tést.txt', 'awesome.txt', (err) => {
         expect(err).to.not.exist;
         expect(fs.existsSync(`${clientDirectory}/${name}/tést.txt`)).to.equal(false);
         expect(fs.existsSync(`${clientDirectory}/${name}/awesome.txt`)).to.equal(true);
@@ -264,7 +264,7 @@ describe('Integration', function () {
       });
     });
 
-    it('SIZE awesome.txt', done => {
+    it('SIZE awesome.txt', (done) => {
       client.size('awesome.txt', (err, size) => {
         expect(err).to.not.exist;
         expect(size).to.be.a('number');
@@ -272,7 +272,7 @@ describe('Integration', function () {
       });
     });
 
-    it('MDTM awesome.txt', done => {
+    it('MDTM awesome.txt', (done) => {
       client.lastMod('awesome.txt', (err, modTime) => {
         expect(err).to.not.exist;
         expect(modTime).to.be.instanceOf(Date);
@@ -281,14 +281,14 @@ describe('Integration', function () {
       });
     });
 
-    it.skip('MLSD .', done => {
+    it.skip('MLSD .', (done) => {
       client.mlsd('.', () => {
         done();
       });
     });
 
-    it('SITE CHMOD 700 awesome.txt', done => {
-      client.site('CHMOD 600 awesome.txt', err => {
+    it('SITE CHMOD 700 awesome.txt', (done) => {
+      client.site('CHMOD 600 awesome.txt', (err) => {
         expect(err).to.not.exist;
         fs.stat(`${clientDirectory}/${name}/awesome.txt`, (fserr, stats) => {
           expect(fserr).to.not.exist;
@@ -299,27 +299,27 @@ describe('Integration', function () {
       });
     });
 
-    it('DELE awesome.txt', done => {
-      client.delete('awesome.txt', err => {
+    it('DELE awesome.txt', (done) => {
+      client.delete('awesome.txt', (err) => {
         expect(err).to.not.exist;
         expect(fs.existsSync(`${clientDirectory}/${name}/awesome.txt`)).to.equal(false);
         done();
       });
     });
 
-    it('MKD témp', done => {
+    it('MKD témp', (done) => {
       const path = `${clientDirectory}/${name}/témp`;
       if (fs.existsSync(path)) {
         fs.rmdirSync(path);
       }
-      client.mkdir('témp', err => {
+      client.mkdir('témp', (err) => {
         expect(err).to.not.exist;
         expect(fs.existsSync(path)).to.equal(true);
         done();
       });
     });
 
-    it('CWD témp', done => {
+    it('CWD témp', (done) => {
       client.cwd('témp', (err, data) => {
         expect(err).to.not.exist;
         expect(data).to.to.be.a('string');
@@ -327,23 +327,23 @@ describe('Integration', function () {
       });
     });
 
-    it('CDUP', done => {
-      client.cdup(err => {
+    it('CDUP', (done) => {
+      client.cdup((err) => {
         expect(err).to.not.exist;
         done();
       });
     });
 
-    it('RMD témp', done => {
-      client.rmdir('témp', err => {
+    it('RMD témp', (done) => {
+      client.rmdir('témp', (err) => {
         expect(err).to.not.exist;
         expect(fs.existsSync(`${clientDirectory}/${name}/témp`)).to.equal(false);
         done();
       });
     });
 
-    it('CDUP', done => {
-      client.cdup(err => {
+    it('CDUP', (done) => {
+      client.cdup((err) => {
         expect(err).to.not.exist;
         done();
       });
@@ -362,8 +362,8 @@ describe('Integration', function () {
 
     after(() => closeClient(client));
 
-    it('TYPE A', done => {
-      client.ascii(err => {
+    it('TYPE A', (done) => {
+      client.ascii((err) => {
         expect(err).to.not.exist;
         done();
       });
@@ -384,8 +384,8 @@ describe('Integration', function () {
 
     after(() => closeClient(client));
 
-    it('TYPE I', done => {
-      client.binary(err => {
+    it('TYPE I', (done) => {
+      client.binary((err) => {
         expect(err).to.not.exist;
         done();
       });

--- a/test/start.js
+++ b/test/start.js
@@ -5,7 +5,7 @@ const FtpServer = require('../src');
 
 const server = new FtpServer({
   log: bunyan.createLogger({name: 'test', level: 'trace'}),
-  url: 'ftps://127.0.0.1:8880',
+  url: 'ftp://127.0.0.1:8880',
   pasv_min: 8881,
   greeting: ['Welcome', 'to', 'the', 'jungle!'],
   tls: {


### PR DESCRIPTION
- Use correct socket event (`end`)
- Destroy socket once ended, not prematurely
- Wait for secure handshake process to be connected

Also enables eslint rule `arrow-parens`