### PR TITLE
URL wasn't passed to FtpSrv from CLI

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -105,7 +105,8 @@ function startFtpServer(_state) {
     return reject(new errors.GeneralError('Invalid username or password', 401));
   }
 
-  const ftpServer = new FtpSrv(_state.url, {
+  const ftpServer = new FtpSrv({
+    url: _state.url,
     anonymous: _state.anonymous,
     blacklist: _state.blacklist
   });


### PR DESCRIPTION
Starting  from CLI as unprivileged user resulted in a EACCES error. This was a symptom of the URL not being passed correctly to the FtpServ class. Fixed in this patch.