### PR TITLE
Remove null/undefined values in FtpSrv constructor options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,11 @@ const {getNextPortFactory} = require('./helpers/find-port');
 class FtpServer extends EventEmitter {
   constructor(options = {}) {
     super();
+    // Remove null/undefined options so they get set to defaults, below
+    for (const k in options) {
+      if (options[k] == null) delete options[k];
+    }
+
     this.options = Object.assign({
       log: buyan.createLogger({name: 'ftp-srv'}),
       url: 'ftp://127.0.0.1:21',


### PR DESCRIPTION
Running the CLI with no args fails due to `Parameter "url" must be a string, not undefined` because it passes `url: undefined` in the FtpSrv constructor options.  Simplest fix is to just purge options of any null/undefined values before `Object.assign()`ing the default values.