### PR TITLE
Null check in getNextPortFactory()

### DIFF
--- a/src/helpers/find-port.js
+++ b/src/helpers/find-port.js
@@ -20,10 +20,14 @@ function getNextPortFactory(min, max = Infinity) {
     portCheckServer.listen(nextPortNumber.next().value);
   });
 
-  return () => new Promise((resolve) => {
+  return () => new Promise((resolve, reject) => {
     portCheckServer.once('listening', () => {
-      const {port} = portCheckServer.address();
-      portCheckServer.close(() => resolve(port));
+      const address = portCheckServer.address();
+      if (address) {
+        portCheckServer.close(() => resolve(address.port));
+      } else {
+        reject(Error('Unable to find server port'));
+      }
     });
     portCheckServer.listen(nextPortNumber.next().value);
   })

--- a/src/helpers/find-port.js
+++ b/src/helpers/find-port.js
@@ -21,15 +21,16 @@ function getNextPortFactory(min, max = Infinity) {
   });
 
   return () => new Promise((resolve, reject) => {
+    const port = nextPortNumber.next().value;
     portCheckServer.once('listening', () => {
       const address = portCheckServer.address();
       if (address) {
         portCheckServer.close(() => resolve(address.port));
       } else {
-        reject(Error('Unable to find server port'));
+        reject(Error(`Port ${port} not available`));
       }
     });
-    portCheckServer.listen(nextPortNumber.next().value);
+    portCheckServer.listen(port);
   })
   .catch(RangeError, (err) => Promise.reject(new errors.ConnectorError(err.message)));
 }


### PR DESCRIPTION
For #137 

This traps the null case and throws a more descriptive error, but doesn't fix the general problem, which is that there's no error handling for failure to listen on a data server.

Having getNextPasvPort() keep try some > 1 port would mitigate this issue, but doesn't completely solve the problem.