### PR TITLE
fix: add correct typing for tls option

### DIFF
--- a/ftp-srv.d.ts
+++ b/ftp-srv.d.ts
@@ -64,7 +64,7 @@ export interface FtpServerOptions {
     pasv_max?: number,
     pasv_url?: string,
     greeting?: string | string[],
-    tls?: tls.SecureContext | false,
+    tls?: tls.SecureContextOptions | false,
     anonymous?: boolean,
     blacklist?: Array<string>,
     whitelist?: Array<string>,


### PR DESCRIPTION
Based on the typings, I first configured tls as follows, which let to a vague error `ssl3_get_client_hello:no shared cipher`:

```javascript
const server = new FtpSrv({
  url: process.env.FTP_CONNECTION_STR,
  tls: tls.createSecureContext({
    key: fs.readFileSync('./cert/server.pem'),
    cert: fs.readFileSync('./cert/public-cert.pem'),
  }),
});
```

The tls server option doesn't expect `SecureContext`, but `SecureContextOptions` like this:

```javascript
const server = new FtpSrv({
  url: process.env.FTP_CONNECTION_STR,
  tls: {
    key: fs.readFileSync('./cert/server.pem'),
    cert: fs.readFileSync('./cert/public-cert.pem'),
  },
});
```