### PR TITLE
Listing empty folders sends back a response

### DIFF
--- a/src/commands/registration/list.js
+++ b/src/commands/registration/list.js
@@ -36,6 +36,7 @@ module.exports = {
     .tap(() => this.reply(150))
     .then((fileList) => {
       if (fileList.length) return this.reply({}, ...fileList);
+      return this.reply({socket: this.connector.socket, useEmptyMessage: true});
     })
     .tap(() => this.reply(226))
     .catch(Promise.TimeoutError, (err) => {

--- a/src/connection.js
+++ b/src/connection.js
@@ -104,8 +104,10 @@ class FtpConnection extends EventEmitter {
           else if (typeof letter === 'string') letter = {message: letter}; // allow passing in message as first param
 
           if (!letter.socket) letter.socket = options.socket ? options.socket : this.commandSocket;
-          if (!letter.message) letter.message = DEFAULT_MESSAGE[options.code] || 'No information';
-          if (!letter.encoding) letter.encoding = this.encoding;
+          if (!options.useEmptyMessage) {
+            if (!letter.message) letter.message = DEFAULT_MESSAGE[options.code] || 'No information';
+            if (!letter.encoding) letter.encoding = this.encoding;
+          }
           return Promise.resolve(letter.message) // allow passing in a promise as a message
           .then((message) => {
             const seperator = !options.hasOwnProperty('eol') ?


### PR DESCRIPTION
Prevent FTP clients to crash with an exception, when they use encryption and want to list an empty folder on the FTP server.