### PR TITLE
feat(commands): implement RFC 7151 (File Transfer Protocol HOST Command for Virtual Hosts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,26 @@ Set the password for the given `username`.
 
 The `FtpSrv` class extends the [node net.Server](https://nodejs.org/api/net.html#net_class_net_server). Some custom events can be resolved or rejected, such as `login`.
 
+### `virtualhost`
+```js
+ftpServer.on('virtualhost', ({connection, host}, resolve, reject) => { ... })
+```
+
+Occurs when client sets hostname using the `HOST` command before authentication. If you attach a listener to this event, you can make the server [RFC 7151](https://tools.ietf
+.org/html/rfc7151) compliant. Here you can setup an environment for different virtualhosts. Note that the client may change the host multiple times before a successful authentication, the last successful attempt will be saved in that case.
+
+`connection` [client class object](src/connection.js)  
+`host` string of hostname from `HOST` command  
+`resolve` takes an object of arguments:  
+- `motd`
+  - Array of lines from the welcome message of the virtualhost.
+  - The last line will always be _Host accepted_ regardless of this argument.
+
+`reject` takes an error object
+
 ### `login`
 ```js
-ftpServer.on('login', ({connection, username, password}, resolve, reject) => { ... });
+ftpServer.on('login', ({connection, username, password, host}, resolve, reject) => { ... });
 ```
 
 Occurs when a client is attempting to login. Here you can resolve the login request by username and password.
@@ -191,6 +208,7 @@ Occurs when a client is attempting to login. Here you can resolve the login requ
 `connection` [client class object](src/connection.js)  
 `username` string of username from `USER` command  
 `password` string of password from `PASS` command  
+`host` string of hostname from `HOST` command, if issued before login  
 `resolve` takes an object of arguments:  
 - `fs`
   - Set a custom file system class for this connection to use.

--- a/ftp-srv.d.ts
+++ b/ftp-srv.d.ts
@@ -53,7 +53,7 @@ export class FtpConnection extends EventEmitter {
 	secure: boolean
 
 	close (code: number, message: number): Promise<any>
-	login (username: string, password: string): Promise<any>
+	login (username: string, password: string, host: string): Promise<any>
 	reply (options: number | Object, ...letters: Array<any>): Promise<any>
 
 }
@@ -98,11 +98,23 @@ export class FtpServer extends EventEmitter {
 
     close(): any;
 
+  on(event: "virtualhost", listener: (
+    data: {
+      connection: FtpConnection,
+      host: string
+    },
+    resolve: (config: {
+      motd?: Array<string>
+    }) => void,
+    reject: (err?: Error) => void
+  ) => void): this
+
 	on(event: "login", listener: (
 		data: {
 			connection: FtpConnection,
 			username: string,
-			password: string
+			password: string,
+      host: string
 		},
 		resolve: (config: {
             fs?: FileSystem,

--- a/src/commands/registration/host.js
+++ b/src/commands/registration/host.js
@@ -1,0 +1,30 @@
+module.exports = {
+  directive: 'HOST',
+  handler: function ({log, command} = {}) {
+    if (this.authenticated) return this.reply(503, 'Already logged in');
+
+    const host = command.arg;
+    if (!host) return this.reply(501, 'Must provide hostname');
+
+    const virtualhostListeners = this.server.listeners('virtualhost');
+    if (!virtualhostListeners || virtualhostListeners.length == 0) {
+      return this.reply(501, 'This server does not handle virtualhost changes');
+    } else {
+      return this.server.emitPromise('virtualhost', {connection: this, host}).then(
+        ({motd = []}) => {
+          this.host = host
+          this.reply(220, 'Host accepted', ...motd)
+        },
+        (err) => {
+          log.error(err)
+          return this.reply(err.code || 504, err.message || (!err.code && 'Host rejected'))
+        }
+      );
+    }
+  },
+  syntax: '{{cmd}} <hostname>',
+  description: 'Virtual host',
+  flags: {
+    no_auth: true
+  }
+};

--- a/src/commands/registration/pass.js
+++ b/src/commands/registration/pass.js
@@ -8,7 +8,7 @@ module.exports = {
 
     const password = command.arg;
     if (!password) return this.reply(501, 'Must provide password');
-    return this.login(this.username, password)
+    return this.login(this.username, password, this.host)
     .then(() => {
       return this.reply(230);
     })

--- a/src/commands/registration/user.js
+++ b/src/commands/registration/user.js
@@ -9,7 +9,7 @@ module.exports = {
 
     if (this.server.options.anonymous === true && this.username === 'anonymous' ||
         this.username === this.server.options.anonymous) {
-      return this.login(this.username, '@anonymous')
+      return this.login(this.username, '@anonymous', this.host)
       .then(() => {
         return this.reply(230);
       })

--- a/src/commands/registry.js
+++ b/src/commands/registry.js
@@ -9,6 +9,7 @@ const commands = [
   require('./registration/dele'),
   require('./registration/feat'),
   require('./registration/help'),
+  require('./registration/host'),
   require('./registration/list'),
   require('./registration/mdtm'),
   require('./registration/mkd'),

--- a/src/connection.js
+++ b/src/connection.js
@@ -75,13 +75,13 @@ class FtpConnection extends EventEmitter {
       .then(() => this.commandSocket && this.commandSocket.end());
   }
 
-  login(username, password) {
+  login(username, password, host) {
     return Promise.try(() => {
       const loginListeners = this.server.listeners('login');
       if (!loginListeners || !loginListeners.length) {
         if (!this.server.options.anonymous) throw new errors.GeneralError('No "login" listener setup', 500);
       } else {
-        return this.server.emitPromise('login', {connection: this, username, password});
+        return this.server.emitPromise('login', {connection: this, username, password, host});
       }
     })
     .then(({root, cwd, fs, blacklist = [], whitelist = []} = {}) => {


### PR DESCRIPTION
Fix #114 

Todo:
  - [x] Add handler for command
  - [x] Add listener
  - [x] Provide option for checking hostname just at login time
  - [ ] Checking for hostname (domain name / ip literal) syntax according to [section 3.1](https://tools.ietf.org/html/rfc7151#section-3.1), including port number persistence
  - [ ] Checking if IP address matches server IP (in case supplied) ([section 3.1](https://tools.ietf.org/html/rfc7151#section-3.1))
  - [ ] When TLS used, checking if supplied hostname matches with one from TLS ([section 3.2.2](https://tools.ietf.org/html/rfc7151#section-3.2.2))
  - [ ] CLI options (specifying a map between virtualhosts and user/pass/root combos)
  - [ ] Tests