### PR TITLE
feat: 'disconnect' event

### DIFF
--- a/ftp-srv.d.ts
+++ b/ftp-srv.d.ts
@@ -112,6 +112,13 @@ export class FtpServer extends EventEmitter {
             whitelist?: Array<string>
         }) => void,
 		reject: (err?: Error) => void
+  ) => void): this;
+
+	on(event: "disconnect", listener: (
+		data: {
+      connection: FtpConnection,
+      id: string
+		}
 	) => void): this;
 
 	on(event: "client-error", listener: (

--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,8 @@ class FtpServer extends EventEmitter {
       _.get(this, 'options.pasv_min'),
       _.get(this, 'options.pasv_max'));
 
-	const timeout = Number(this.options.timeout);
-	this.options.timeout = isNaN(timeout) ? 0 : Number(timeout);
+    const timeout = Number(this.options.timeout);
+    this.options.timeout = isNaN(timeout) ? 0 : Number(timeout);
 
     const serverConnectionHandler = (socket) => {
       socket.setTimeout(this.options.timeout);
@@ -53,7 +53,7 @@ class FtpServer extends EventEmitter {
       const greeting = this._greeting || [];
       const features = this._features || 'Ready';
       return connection.reply(220, ...greeting, features)
-      .finally(() => socket.resume());
+        .finally(() => socket.resume());
     };
     const serverOptions = Object.assign({}, this.isTLS ? this.options.tls : {}, {pauseOnConnect: true});
 
@@ -119,6 +119,7 @@ class FtpServer extends EventEmitter {
     return new Promise((resolve) => {
       const client = this.connections[id];
       if (!client) return resolve();
+      this.emit('disconnect', {connection: client, id});
       delete this.connections[id];
       try {
         client.close(0);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -369,6 +369,39 @@ describe('Integration', function () {
     });
   }
 
+  describe('Server events', function () {
+    const disconnect = sinon.spy();
+    const login = sinon.spy();
+
+    before(() => {
+      server.on('login', login);
+      server.on('disconnect', disconnect);
+      return connectClient({
+        host: server.url.hostname,
+        port: server.url.port,
+        user: 'test',
+        password: 'test'
+      });
+    });
+
+    after(() => {
+      server.off('login', login);
+      server.off('disconnect', disconnect);
+    })
+
+    it('should fire a login event on connect', () => {
+      expect(login.calledOnce).to.be.true;
+    });
+
+    it('should fire a close event on disconnect', (done) => {
+      client.end();
+      setTimeout(() => {
+        expect(disconnect.calledOnce).to.be.true;
+        done();
+      }, 100)
+    });
+  });
+
   describe('#ASCII', function () {
     before(() => {
       return connectClient({


### PR DESCRIPTION
This PR adds a `disconnect` event that fires whenever a client is removed from the list of active connections.

Types and tests for this PR are already implemented.

This fixes #174